### PR TITLE
feat: bumped actions/create-github-app to latest (1.11.6) version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,7 +309,7 @@ jobs:
           git commit -m "$commit_message" || echo "No changes to commit"
       - name: Generate a token
         id: generate-tokens
-        uses: actions/create-github-app-token@v1.11.5
+        uses: actions/create-github-app-token@v1.11.6
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_SECRET }}


### PR DESCRIPTION
Hi @Rumixyz 
I have bumped `actions/create-github-app` to latest (1.11.6) version
Here is the latest release : https://github.com/actions/create-github-app-token/releases/tag/v1.11.6 changelog.

Fixes #2
/claim #2